### PR TITLE
Usar requests con data

### DIFF
--- a/mysolr/mysolr.py
+++ b/mysolr/mysolr.py
@@ -133,7 +133,7 @@ class Solr:
         """
         url = '%s/update' % (self.base_url)
         response = requests.post(url, data=xml.encode('utf-8'),
-                                 headers={'Content-Type': 'text/xml'})
+                                 headers={'Content-Type': 'text/xml; charset=utf-8'})
         response.raise_for_status()
     
     def _post_json(self, json_doc):
@@ -142,7 +142,7 @@ class Solr:
         """
         url = '%s/update/json' % (self.base_url)
         response = requests.post(url, data=json_doc.encode('utf-8'),
-                                 headers={'Content-Type': 'application/json'})
+                                 headers={'Content-Type': 'application/json; charset=utf-8'})
         response.raise_for_status()
 
 def _get_add_xml(array_of_hash, overwrite=True):


### PR DESCRIPTION
Al final parece ser que añadiendo al 'header' 'Conten-type' el charset UTF-8 ya no da problemas
