### PR TITLE
Never use eval() to parse data from the network, closes #30

### DIFF
--- a/mysolr/compat.py
+++ b/mysolr/compat.py
@@ -8,6 +8,7 @@
 """
 
 import sys
+import anyjson
 
 if sys.version_info >= (3, ):
     from urllib.parse import urljoin
@@ -15,17 +16,10 @@ elif sys.version_info >= (2, ):
     from urlparse import urljoin
 
 def get_wt():
-    if sys.version_info[0] == 3 and sys.version_info[1] == 2:
-        return 'json'
-    else:
-        return 'python'
+    return 'json'
 
 def parse_response(content):
-    if sys.version_info[0] == 3 and sys.version_info[1] == 2:
-        import json
-        return json.loads(content.decode('utf-8'))
-    else:
-        return eval(content)
+    return anyjson.loads(content.decode('utf-8'))
 
 def compat_args(query):
     for (key, value) in query.items():

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ except ImportError:
     from distutils.core import setup
 
 
-REQUIRED = []
+REQUIRED = ['anyjson']
 
 if sys.version_info >= (3, 3):
     REQUIRED.append('requests>=0.14.1')


### PR DESCRIPTION
the 'json' module is in python's standard library since 2.6 and using
eval() is a huge security risk.
