### PR TITLE
Adding persistent HTTP requests and configurable GET requests

### DIFF
--- a/mysolr/__init__.py
+++ b/mysolr/__init__.py
@@ -5,6 +5,6 @@ from .mysolr import Solr
 from .mysolr import Cursor
 
 __title__ = 'mysolr'
-__version__ = '0.8.1'
+__version__ = '0.8.2'
 __build__ = 0x000080
 __author__ = 'Rubén Abad, Miguel Olivares'

--- a/mysolr/__init__.py
+++ b/mysolr/__init__.py
@@ -5,6 +5,6 @@ from .mysolr import Solr
 from .mysolr import Cursor
 
 __title__ = 'mysolr'
-__version__ = '0.8.2'
+__version__ = '0.8.3'
 __build__ = 0x000080
 __author__ = 'Rubén Abad, Miguel Olivares'

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -13,17 +13,16 @@ class QueryResultTestCase(unittest.TestCase):
     def test_search(self):
         response = self.solr.search(q='*:*')
         self.assertEqual(response.status, 200)
-        self.assertEqual(response.total_results, 4)
-        self.assertEqual(len(response.documents), 4)
+        self.assertEqual(response.total_results, 4563722)
+        self.assertEqual(len(response.documents), 10)
 
     def test_search_persistent(self):
-        solr = Solr(os.getenv('SOLR_URL'), persistent=True)
+        solr = Solr(os.getenv('SOLR_URL'), persistent=True, use_get=True)
         for _ in xrange(10):
             response = solr.search(q='*:*')
             self.assertEqual(response.status, 200)
-            self.assertEqual(response.total_results, 4)
-            self.assertEqual(len(response.documents), 4)
-
+            self.assertEqual(response.total_results, 4563722)
+            self.assertEqual(len(response.documents), 10)
 
     def test_search_cursor(self):
         cursor = self.solr.search_cursor(q='*:*')

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -16,6 +16,15 @@ class QueryResultTestCase(unittest.TestCase):
         self.assertEqual(response.total_results, 4)
         self.assertEqual(len(response.documents), 4)
 
+    def test_search_persistent(self):
+        solr = Solr(os.getenv('SOLR_URL'), persistent=True)
+        for _ in xrange(10):
+            response = solr.search(q='*:*')
+            self.assertEqual(response.status, 200)
+            self.assertEqual(response.total_results, 4)
+            self.assertEqual(len(response.documents), 4)
+
+
     def test_search_cursor(self):
         cursor = self.solr.search_cursor(q='*:*')
         i = 0


### PR DESCRIPTION
This change adds two options:
-  persistent: reuse HTTP connection for consequent requests
- use_get: make GET HTTP requests for search and search_cursor - to allow caching Solr responses (i.e. with Varnish)
