### PR TITLE
remove Connection: close header

### DIFF
--- a/mysolr/mysolr.py
+++ b/mysolr/mysolr.py
@@ -60,7 +60,8 @@ class Solr(object):
         """
         query = build_request(kwargs)
         url = urljoin(self.base_url, resource)
-        headers = {'Connection': 'close'}
+        headers = {}
+        #headers = {'Connection': 'close'}
         if self.use_get:
             http_response = self.make_request.get(url, params=query,
                                                   headers=headers)


### PR DESCRIPTION
"Connection: close" header prevents us from working with keep-alive connections. Which is critical for our application. Lets discuss what will be the best way to manage this in your mysolr library.
