### PR TITLE
don't depend on coveralls from setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - "3.4"
 # command to install dependencies
 install:
-  - pip install . --use-mirrors
+  - pip install coveralls . --use-mirrors
 env:
   - SOLR_VERSION=3.6.2 SOLR_URL=http://localhost:8983/solr SOLR_DOCS=apache-solr-3.6.2/example/exampledocs/books.json
   - SOLR_VERSION=4.8.0 SOLR_URL=http://localhost:8983/solr/collection1 SOLR_DOCS=solr-4.8.0/example/exampledocs/books.json

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Chages
 ======
 
+v 0.8.4
+-------
+- Don't depend on coveralls
+
 v 0.8.3
 -------
 - New utils module

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ except ImportError:
     from distutils.core import setup
 
 
-REQUIRED = ['anyjson', 'coveralls', 'requests>=2.2.1']
+REQUIRED = ['anyjson', 'requests>=2.2.1']
 
 if sys.version_info < (2, 7, ):
     REQUIRED.append('ordereddict')
@@ -29,7 +29,7 @@ CLASSIFIERS = [
 
 
 setup(name='mysolr',
-      version='0.8.3',
+      version='0.8.4',
       description='Solr Python binding',
       long_description = open('README.rst').read(),
       author='Rubén Abad, Miguel Olivares',


### PR DESCRIPTION
depending on it there installs it (and all its dependencies) in
"production" installs of mysolr, even though none of the actual running
code depends on coveralls

Note: I can't get the travis tests to pass on my branch, there's some issue with the Solr instance that is being spun up in the travis scripts. However, I don't think this should have any impact on the actual build, though I haven't been able to fully verify that.
